### PR TITLE
Remove the definitions of command and thunk

### DIFF
--- a/struct.tex
+++ b/struct.tex
@@ -153,7 +153,6 @@ $$
 \vr{pair}&pair\\
 \vr{proc}&procedure\\
 \vr{symbol}&symbol\\
-\vr{thunk}&zero-argument procedure\\
 \end{tabular}
 $$
 
@@ -181,9 +180,4 @@ of procedures that always return a boolean value.
 Such procedures are called \defining{predicates}.
 Predicates are generally understood to be side-effect free, except that they
 may have an error when passed the wrong type of argument.
-
-A \defining{command} is a procedure that does not return useful values
-to its continuation.
-
-A \defining{thunk} is a procedure that does not accept arguments.
 

--- a/syn.tex
+++ b/syn.tex
@@ -156,8 +156,8 @@ the syntax keywords defined in this report have not been redefined or shadowed.
 
 \begin{grammar}%
 \meta{program} \:
-\> \atleastone{\meta{command or definition}}
-\meta{command or definition} \: \meta{expression}
+\> \atleastone{\meta{expression or definition}}
+\meta{expression or definition} \: \meta{expression}
 \> \| \meta{definition}
 \meta{definition} \: (define \meta{identifier} \meta{expression})
 \end{grammar}


### PR DESCRIPTION
These terms are defined but not really useful in pR7RS.