### PR TITLE
display should accept an expression

### DIFF
--- a/syn.tex
+++ b/syn.tex
@@ -160,5 +160,5 @@ the syntax keywords defined in this report have not been redefined or shadowed.
 \meta{expression or definition or io} \: \meta{expression}
 \> \| \meta{definition} \| \meta{io}
 \meta{definition} \: (define \meta{identifier} \meta{expression})
-\meta{io} \: (display \meta{identifier}) \| (newline)
+\meta{io} \: (display \meta{expression}) \| (newline)
 \end{grammar}


### PR DESCRIPTION
Closes #46

In the syntax, it was listed as (display <identifier>) but both for consistentency with the other parts of the document (display obj) and as a practical matter, it should have been (display <expression>)